### PR TITLE
New format that is easier to work with upstream in intl-messageformat

### DIFF
--- a/lib/extract-numbers.js
+++ b/lib/extract-numbers.js
@@ -136,8 +136,14 @@ function loadNumberFields(locale) {
 
 function transform(hash) {
   return FORMAT_FIELD_NAMES.reduce(function (numberFormat, type) {
+    // rules =
+    // {
+    //   '1000-count-one': '0 K',
+    //   '1000-count-other': '0 K'...
+    // }
     var rules = hash[type]['decimalFormat'];
 
+    // example of expected short && long values
     // [
     //   [1000, {one: ["0K", 1], other: ["0K", 1]}],
     //   [10000, %{one: ["00K", 2], other: ["00K", 2]}]
@@ -145,11 +151,7 @@ function transform(hash) {
     var boundaries = [];
     var ruleKeys = Object.keys(rules);
 
-    // rules =
-    // {
-    //   '1000-count-one': '0 K',
-    //   '1000-count-other': '0 K'...
-    // }
+    // ['1000-count-one', '1000-count-other'];
     ruleKeys.forEach(function (key, indx, original) {
       var value = rules[key];
       var modifiedKey = key.split('-');

--- a/lib/extract-numbers.js
+++ b/lib/extract-numbers.js
@@ -13,8 +13,12 @@ var normalizeLocale = require('./locales').normalizeLocale;
 
 // The set of CLDR date field names that are used in FormatJS.
 var NUMBER_FIELD_NAMES = [
-    'decimalFormats-numberSystem-latn',
-    'currencyFormats-numberSystem-latn',
+  'decimalFormats-numberSystem-latn'
+];
+
+var FORMAT_FIELD_NAMES = [
+    'long',
+    'short',
 ];
 
 module.exports = function extractNumberFields(locales) {
@@ -28,14 +32,14 @@ module.exports = function extractNumberFields(locales) {
     // Loads and caches the relative fields for a given `locale` because loading
     // and transforming the data is expensive.
     function getNumberFields(locale) {
-        var relativeFields = fields[locale];
-        if (relativeFields) {
-            return relativeFields;
+        var numberFields = fields[locale];
+        if (numberFields) {
+            return numberFields;
         }
 
         if (hasNumberFields(locale)) {
-            relativeFields = fields[locale] = loadNumberFields(locale);
-            return relativeFields;
+            numberFields = fields[locale] = loadNumberFields(locale);
+            return numberFields;
         }
     }
 
@@ -121,8 +125,64 @@ function loadNumberFields(locale) {
     var fields   = require(filename).main[locale].numbers;
     // Reduce the number fields data down to whitelist of fields needed in the
     // FormatJS libs.
-    return NUMBER_FIELD_NAMES.reduce(function (relative, field) {
-        relative[field] = fields[field];
-        return relative;
+    // e.g. { }
+    return NUMBER_FIELD_NAMES.reduce(function (numbers, field) {
+      if (field.indexOf('decimal') > -1) {
+        numbers['decimal'] = transform(fields[field]);
+        return numbers;
+      }
     }, {});
+}
+
+function transform(hash) {
+  return FORMAT_FIELD_NAMES.reduce(function (numberFormat, type) {
+    var rules = hash[type]['decimalFormat'];
+
+    // [
+    //   [1000, {one: ["0K", 1], other: ["0K", 1]}],
+    //   [10000, %{one: ["00K", 2], other: ["00K", 2]}]
+    // ]
+    var boundaries = [];
+    var ruleKeys = Object.keys(rules);
+
+    // rules =
+    // {
+    //   '1000-count-one': '0 K',
+    //   '1000-count-other': '0 K'...
+    // }
+    ruleKeys.forEach(function (key, indx, original) {
+      var value = rules[key];
+      var modifiedKey = key.split('-');
+      var boundary = +modifiedKey[0];
+      var count = modifiedKey[2];
+      var existingBoundaryIndx = findIndex(boundary, boundaries);
+      var formattingIndicators = [value, numberOfZeros(value)];
+      if (existingBoundaryIndx > -1) {
+        // add to hash either a key of `one` or `other`
+        boundaries[existingBoundaryIndx][1][count] = formattingIndicators;
+      } else {
+        // create new entry in array with boundary and formatting options
+        var options = {};
+        options[count] = formattingIndicators;
+        boundaries.push([ boundary, options ]);
+      }
+    });
+
+    numberFormat[type] = boundaries;
+    return numberFormat;
+  }, {});
+}
+
+function findIndex(boundary, items) {
+  for (let i = 0; i < items.length; i++) {
+    if (items[i][0] === boundary) {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+function numberOfZeros(value) {
+  return (value.match(/0/g) || []).length;
 }

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -221,9 +221,21 @@ describe('extractData()', function () {
                 });
 
                 expect(data.en).to.have.key('numbers');
-                expect(data.en.numbers).to.be.an('object');
-                expect(data.en.numbers).to.have.key('decimalFormats-numberSystem-latn');
-                expect(data.en.numbers).to.have.key('currencyFormats-numberSystem-latn');
+                var numbers = data.en.numbers;
+                expect(numbers).to.be.an('object');
+                expect(numbers).to.have.key('decimal');
+                // [
+                //   [1000, {one: ["0K", 1], other: ["0K", 1]}],
+                //   [10000, %{one: ["00K", 2], other: ["00K", 2]}]
+                // ]
+                expect(numbers.decimal).to.have.key('long');
+                expect(numbers.decimal).to.have.key('short');
+                expect(numbers.decimal.long.length).to.be.greaterThan(1);
+                expect(numbers.decimal.short.length).to.be.greaterThan(1);
+                expect(numbers.decimal.short[0].length).to.be.equal(2);
+                expect(numbers.decimal.short[0][0]).to.be.equal(1000);
+                expect(numbers.decimal.short[0][1]).to.have.key('one');
+                expect(numbers.decimal.short[0][1]).to.have.key('other');
             });
         });
     });


### PR DESCRIPTION
@jasonmit - Here is the proposed format that would make it easier to work with this [PR](https://github.com/ember-intl/intl-messageformat/pull/1/files)

Let me know what you think about the proposed format!

```
decimal: {
  short: [
    [1000, {one: ["0K", 1], other: ["0K", 1]}],
    [10000, %{one: ["00K", 2], other: ["00K", 2]}]
  ],
  long: [...]
}
```

Essentially `1000` is the boundary (check if value <= boundary) and "0K" and 1 are used to determine the format and number of digits respectively.

Note - this is targeting the `sn/number-fields` branch

Ref https://github.com/ember-intl/formatjs-extract-cldr-data/pull/2